### PR TITLE
promoteId can be string or object

### DIFF
--- a/src/components/sources/geojson.source.ts
+++ b/src/components/sources/geojson.source.ts
@@ -28,7 +28,7 @@ export default defineComponent({
 		clusterProperties: Object as PropType<object>,
 		lineMetrics      : Boolean as PropType<boolean>,
 		generateId       : Boolean as PropType<boolean>,
-		promoteId        : Object as PropType<PromoteIdSpecification>,
+		promoteId        : [ Object, String ] as PropType<PromoteIdSpecification>,
 		filter           : [ Array, String, Object ] as PropType<any>
 	},
 	setup(props) {

--- a/src/components/sources/vector.source.ts
+++ b/src/components/sources/vector.source.ts
@@ -20,7 +20,7 @@ export default defineComponent({
 		minzoom    : Number as PropType<number>,
 		maxzoom    : Number as PropType<number>,
 		attribution: String as PropType<string>,
-		promoteId  : Object as PropType<PromoteIdSpecification>
+		promoteId  : [ Object, String ] as PropType<PromoteIdSpecification>
 	},
 	setup(props) {
 


### PR DESCRIPTION
Vue complained with `Invalid prop: type check failed for prop "promoteId". Expected Object, got String with value "id"`. I think it should accept Object or String as per:

- https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#vector-promoteId
- https://github.com/maplibre/maplibre-gl-js/blob/26344c90302385efc5cc2c50cb93e26793f465de/build/generate-style-spec.ts#L132

Appreciate your work :hearts: Thanks!