### PR TITLE
Set default value for filter prop to avoid invalid filter expression

### DIFF
--- a/src/components/layers/circle.layer.ts
+++ b/src/components/layers/circle.layer.ts
@@ -9,7 +9,10 @@ export default /*#__PURE__*/ defineComponent({
 		...LayerLib.SHARED.props,
 		layout: Object as PropType<CircleLayerSpecification['layout']>,
 		paint : Object as PropType<CircleLayerSpecification['paint']>,
-		filter: [ Boolean, Array ] as PropType<CircleLayerSpecification['filter']>
+		filter: {
+			type: [ Boolean, Array ] as PropType<CircleLayerSpecification['filter']>,
+			default: undefined
+		},
 	},
 	emits: [ ...LayerLib.SHARED.emits ],
 	setup(props) {

--- a/src/components/layers/fill.layer.ts
+++ b/src/components/layers/fill.layer.ts
@@ -9,7 +9,10 @@ export default /*#__PURE__*/ defineComponent({
 		...LayerLib.SHARED.props,
 		layout: Object as PropType<FillLayerSpecification['layout']>,
 		paint : Object as PropType<FillLayerSpecification['paint']>,
-		filter: [ Boolean, Array ] as PropType<FillLayerSpecification['filter']>,
+		filter: {
+			type: [ Boolean, Array ] as PropType<FillLayerSpecification['filter']>,
+			default: undefined
+		},
 	},
 	emits: [ ...LayerLib.SHARED.emits ],
 	setup(props) {

--- a/src/components/layers/fillExtrusion.layer.ts
+++ b/src/components/layers/fillExtrusion.layer.ts
@@ -9,7 +9,10 @@ export default /*#__PURE__*/ defineComponent({
 		...LayerLib.SHARED.props,
 		layout: Object as PropType<FillExtrusionLayerSpecification['layout']>,
 		paint : Object as PropType<FillExtrusionLayerSpecification['paint']>,
-		filter: [ Boolean, Array ] as PropType<FillExtrusionLayerSpecification['filter']>
+		filter: {
+			type: [ Boolean, Array ] as PropType<FillExtrusionLayerSpecification['filter']>,
+			default: undefined
+		},
 	},
 	emits: [ ...LayerLib.SHARED.emits ],
 	setup(props) {

--- a/src/components/layers/heatmap.layer.ts
+++ b/src/components/layers/heatmap.layer.ts
@@ -9,7 +9,10 @@ export default /*#__PURE__*/ defineComponent({
 		...LayerLib.SHARED.props,
 		layout: Object as PropType<HeatmapLayerSpecification['layout']>,
 		paint : Object as PropType<HeatmapLayerSpecification['paint']>,
-		filter: [ Boolean, Array ] as PropType<HeatmapLayerSpecification['filter']>
+		filter: {
+			type: [ Boolean, Array ] as PropType<HeatmapLayerSpecification['filter']>,
+			default: undefined
+		},
 	},
 	emits: [ ...LayerLib.SHARED.emits ],
 	setup(props) {

--- a/src/components/layers/hillshade.layer.ts
+++ b/src/components/layers/hillshade.layer.ts
@@ -9,7 +9,10 @@ export default /*#__PURE__*/ defineComponent({
 		...LayerLib.SHARED.props,
 		layout: Object as PropType<HillshadeLayerSpecification['layout']>,
 		paint : Object as PropType<HillshadeLayerSpecification['paint']>,
-		filter: [ Boolean, Array ] as PropType<HillshadeLayerSpecification['filter']>
+		filter: {
+			type: [ Boolean, Array ] as PropType<HillshadeLayerSpecification['filter']>,
+			default: undefined
+		},
 	},
 	emits: [ ...LayerLib.SHARED.emits ],
 	setup(props) {

--- a/src/components/layers/line.layer.ts
+++ b/src/components/layers/line.layer.ts
@@ -9,7 +9,10 @@ export default /*#__PURE__*/ defineComponent({
 		...LayerLib.SHARED.props,
 		layout: Object as PropType<LineLayerSpecification['layout']>,
 		paint : Object as PropType<LineLayerSpecification['paint']>,
-		filter: [ Boolean, Array ] as PropType<LineLayerSpecification['filter']>
+		filter: {
+			type: [ Boolean, Array ] as PropType<LineLayerSpecification['filter']>,
+			default: undefined
+		},
 	},
 	emits: [ ...LayerLib.SHARED.emits ],
 	setup(props) {

--- a/src/components/layers/raster.layer.ts
+++ b/src/components/layers/raster.layer.ts
@@ -9,7 +9,10 @@ export default /*#__PURE__*/ defineComponent({
 		...LayerLib.SHARED.props,
 		layout: Object as PropType<RasterLayerSpecification['layout']>,
 		paint : Object as PropType<RasterLayerSpecification['paint']>,
-		filter: [ Boolean, Array ] as PropType<RasterLayerSpecification['filter']>
+		filter: {
+			type: [ Boolean, Array ] as PropType<RasterLayerSpecification['filter']>,
+			default: undefined
+		},
 	},
 	emits: [ ...LayerLib.SHARED.emits ],
 	setup(props) {

--- a/src/components/layers/smybol.layer.ts
+++ b/src/components/layers/smybol.layer.ts
@@ -9,7 +9,10 @@ export default /*#__PURE__*/ defineComponent({
 		...LayerLib.SHARED.props,
 		layout: Object as PropType<SymbolLayerSpecification['layout']>,
 		paint : Object as PropType<SymbolLayerSpecification['paint']>,
-		filter: [ Boolean, Array ] as PropType<SymbolLayerSpecification['filter']>
+		filter: {
+			type: [ Boolean, Array ] as PropType<SymbolLayerSpecification['filter']>,
+			default: undefined
+		},
 	},
 	emits: [ ...LayerLib.SHARED.emits ],
 	setup(props) {


### PR DESCRIPTION
Vue's prop system defaults Boolean props to false when not explicitly passed. MapLibre GL seems to treat `filter: false` as an invalid filter expression, silently breaking the layer render.